### PR TITLE
[OOCS-32] Parameters on paths.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ list_response = Response(
 )
 
 detail_response = Response(
-    status=200, description='Here is your orders list.', body=resource
+    status=200, description='Here is your order.', body=resource
 )
 
 error_response = Response(status=404, resource=error_resource, headers=[('Content-type': 'application-json')])
@@ -90,8 +90,7 @@ object as `payload`.
 get_request = Request(verb=verbs.GET)
 ```
 
-An `Action` groups your request and a list of responses for an specified action
-passed in description parameter.
+An `Action` groups your request and a list of responses for a specified action passed in the description parameter.
 ```python
 list_action = Action(
     description='Returns a list of resources.',

--- a/README.md
+++ b/README.md
@@ -72,28 +72,40 @@ You can define `Response` objects with `status`, `description`(optional)  a
 `header`(optional) and a `Resource`/`ListResource` object as `body` (optionally)...
 
 ```python
-ok_response = Response(
+list_response = Response(
     status=200, description='Here is your orders list.', body=list_resource
 )
 
-error_response = Response(status=400, resource=error_resource, headers=[('Content-type': 'application-json')])
+detail_response = Response(
+    status=200, description='Here is your orders list.', body=resource
+)
+
+error_response = Response(status=404, resource=error_resource, headers=[('Content-type': 'application-json')])
 ```
 
 ... and `Request` objects with `verb`, `description`, `header`(optional) and a `Resource`/`ListResource`
 object as `payload`.
 
 ```python
-request = Request(verb=verbs.GET, payload=resource)
+get_request = Request(verb=verbs.GET)
 ```
 
 An `Action` groups your request and a list of responses for an specified action
 passed in description parameter.
 ```python
-action = Action(
+list_action = Action(
     description='Returns a list of resources.',
-    request=request,
-    responses=[error_response, ok_response]
+    request=get_request,
+    responses=[error_response, list_response]
 )
+
+detail_action = Action(
+    description='Returns a resource based on its code.',
+    request=get_request,
+    responses=[error_response, detail_response]
+)
+
+
 ```
 The Action object, as all other elements in Pactum, receive a description string
 that sets the `.__doc__` attribute and can be the docstring of the class
@@ -101,18 +113,20 @@ if the object is defined by class definition.
 
 A route can have a list of actions in an HTTP path.
 ```python
-class OrdersRoute(Route):
+class OrderListRoute(Route):
     path = '/orders'
-    actions = [action]
+    actions = [list_action]
 
-route = OrdersRoute()
+list_route = OrderListRoute()
+
+detail_route = OrderRoute(path='/orders/{code}', actions=detail_action)
 ```
 
 Your routes can be grouped in API versions.
 ```python
 class V1(Version):
     name = 'V1'
-    routes = [route]
+    routes = [list_route, detail_route]
 
 v1 = V1()
 ```
@@ -136,7 +150,7 @@ pactum-openapi <spec_file.py> <output_file> [--format=<json or yaml>]
 # Road to version 1.
 - [ ] Test elements .accept(visitor) methods.
 - [ ] Support for version selectors (Versions should be specified on HTTP header, path, or custom fields)
-- [ ] Stabilize the way we work with path parameters.
+- [x] Stabilize the way we work with path parameters.
 - [ ] Support for Authorization and Authentication Specifications.
 - [ ] Support for extensions.
 - [ ] Behaviors

--- a/pactum/route.py
+++ b/pactum/route.py
@@ -1,3 +1,4 @@
+import re
 from .base import Element
 
 
@@ -12,8 +13,13 @@ class Route(Element):
             except AttributeError:
                 raise TypeError("Missing path specification.")
         self.path = path
+        self.parameters = self._get_parameters(path)
 
         self._initialize_children(locals())
+
+    def _get_parameters(self, path):
+        parameters_re = re.compile(r'\{(?P<parameter>[\.\w-]+)\}')
+        return parameters_re.findall(path)
 
     def accept(self, visitor):
         visitor.visit_route(self)

--- a/samples/orders_api.py
+++ b/samples/orders_api.py
@@ -50,7 +50,8 @@ class OrderListRoute(pactum.Route):
             responses=[
                 pactum.Response(
                     status=200,
-                    body=OrderListResource())
+                    body=OrderListResource()
+                )
             ],
             description='List Orders'
         )

--- a/samples/orders_api.py
+++ b/samples/orders_api.py
@@ -35,8 +35,11 @@ class OrderResource(pactum.Resource):
     ]
 
 
+order_resource = OrderResource()
+
+
 class OrderListResource(pactum.ListResource):
-    resource = OrderResource()
+    resource = order_resource
 
 
 class OrderListRoute(pactum.Route):
@@ -54,6 +57,21 @@ class OrderListRoute(pactum.Route):
     ]
 
 
+class OrderDetailRoute(pactum.Route):
+    path = "/order/{code}"
+    actions = [
+        pactum.Action(
+            request=pactum.Request(verb=verbs.GET),
+            responses=[
+                pactum.Response(
+                    status=200,
+                    body=order_resource)
+            ],
+            description='Retrieve order by code.'
+        )
+    ]
+
+
 api = pactum.API(
     name="Orders API",
     versions=[
@@ -61,6 +79,7 @@ api = pactum.API(
             name="v1",
             routes=[
                 OrderListRoute(),
+                OrderDetailRoute(),
             ]
         )
     ]

--- a/tests/test_exporters/test_openapi.py
+++ b/tests/test_exporters/test_openapi.py
@@ -57,7 +57,6 @@ def test_visit_route_sets_specs_paths():
     assert paths['/test-path/']['summary'] == ''
     assert paths['/test-path/']['description'] == 'Route for tests.'
     assert paths['/test-path/']['servers'] == []
-    assert paths['/test-path/']['parameters'] == {}
 
 
 def test_visit_action_populates_paths_verbs():
@@ -81,6 +80,38 @@ def test_visit_action_populates_paths_verbs():
     assert parsed_action['tags'] == []
     assert parsed_action['externalDocs'] == []
     assert parsed_action['parameters'] == []
+    assert parsed_action['responses'] == {}
+    assert parsed_action['callbacks'] == []
+    assert parsed_action['security'] == {}
+    assert parsed_action['servers'] == {}
+
+
+def test_visit_action_populates_paths_verbs_with_parameters():
+    exporter = OpenAPIV3Exporter()
+    route = Route(path='/test-path/{code}', description='Route for tests.')
+    request = Request(verb=verbs.GET)
+    action = Action(request=request, responses=[], description='Testing action')
+    action.parent = route
+
+    exporter.result['paths'] = {'/test-path/{code}': {}}
+
+    exporter.visit_action(action)
+
+    assert 'get' in exporter.result['paths']['/test-path/{code}']
+    parsed_action = exporter.result['paths']['/test-path/{code}']['get']
+    assert parsed_action['description'] == 'Testing action'
+    assert parsed_action['summary'] == 'Testing action'
+    assert parsed_action['operationId'] == 'TestingAction'
+    assert parsed_action['deprecated'] is False
+
+    assert parsed_action['tags'] == []
+    assert parsed_action['externalDocs'] == []
+    assert len(parsed_action['parameters']) == 1
+    assert parsed_action['parameters'][0] == {
+        'name': 'code',
+        'in': 'path',
+        'required': True
+    }
     assert parsed_action['responses'] == {}
     assert parsed_action['callbacks'] == []
     assert parsed_action['security'] == {}

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -8,6 +8,7 @@ def test_basic_route():
 
     assert route.path == '/test/'
     assert len(route.actions) == 0
+    assert route.parameters == []
 
 
 def test_route_class_definition():
@@ -19,6 +20,7 @@ def test_route_class_definition():
 
     assert route.path == '/test/'
     assert len(route.actions) == 0
+    assert route.parameters == []
 
 
 def test_prefer_parameter_to_class_definition(action):
@@ -39,3 +41,17 @@ def test_prefer_parameter_to_class_definition(action):
 def test_fail_route_with_no_path(resource):
     with pytest.raises(TypeError):
         Route(actions=[])
+
+
+def test_route_with_parameters():
+    route = Route('/test/{test-id}', actions=[])
+
+    assert route.path == '/test/{test-id}'
+    assert route.parameters == ['test-id']
+
+
+def test_route_with_multiple_parameters():
+    route = Route('/test/{test_id}/{test.slug}/{test-uuid}', actions=[])
+
+    assert route.path == '/test/{test_id}/{test.slug}/{test-uuid}'
+    assert route.parameters == ['test_id', 'test.slug', 'test-uuid']


### PR DESCRIPTION
**What**

This PR adds the ability of adding parameters to URLs using curly-brackets notation on routes paths. It means pactum now understands this notation and adds a parameter attribute base on it.

Example:
```python
class OrderDetailRoute(pactum.Route):
    path = "/order/{code}"

route = OrderDetailRoute()
route.parameters == ['code']
```

The exporter for openapi is capable of understanding the new attribute and tries to link it to a resource field.

Example output:
```json
"paths": {
    "/order/{code}": {
      "get": {
        "description": "Retrieve order by code.",
        "summary": "Retrieve order by code.",
        "operationId": "RetrieveOrderByCode.",
        "parameters": [
          {
            "name": "code",
            "in": "path",
            "required": true,
            "schema": {
              "$ref": "#/components/schemas/OrderResource/properties/code"
            }
          }
        ],
        "responses": {
          "200": {
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/OrderResource"
                }
              }
            }
          }
        }
```



**Why:**
To spec APIs with parameters in URLs.

Story: https://jira-olist.atlassian.net/browse/OOCS-2
Task: https://jira-olist.atlassian.net/browse/OOCS-32