### PR TITLE
[OOCS-33] Querystring element on Route

### DIFF
--- a/pactum/__init__.py
+++ b/pactum/__init__.py
@@ -1,6 +1,7 @@
 from . import fields, verbs  # NOQA
 from .action import Action  # NOQA
 from .api import API  # NOQA
+from .querystring import Querystring # NOQA
 from .resources import ListResource, Resource  # NOQA
 from .response import Response  # NOQA
 from .request import Request  # NOQA

--- a/pactum/__init__.py
+++ b/pactum/__init__.py
@@ -1,4 +1,4 @@
-from .import fields, verbs  # NOQA
+from . import fields, verbs  # NOQA
 from .action import Action  # NOQA
 from .api import API  # NOQA
 from .resources import ListResource, Resource  # NOQA

--- a/pactum/base.py
+++ b/pactum/base.py
@@ -22,3 +22,19 @@ class Element:
         child_attr = getattr(self, self._children_name, [])
         child_attr.append(child)
         child.parent = self
+
+
+class KeyValueElement(Element):
+    def __init__(self, name=None, type=None, required=None, **kwargs):
+        super().__init__(**kwargs)
+        if required is None:
+            required = getattr(self, 'required', False)
+        self.required = required
+
+        if name is None:
+            name = getattr(self, 'name', '')
+        self.name = name
+
+        if type is None:
+            type = getattr(self, 'type', self.__class__)
+        self.type = type

--- a/pactum/exporters/openapi.py
+++ b/pactum/exporters/openapi.py
@@ -106,7 +106,7 @@ class OpenAPIV3Exporter(BaseVisitor):
             'name': querystring.name,
             'in': 'query',
             'required': querystring.required,
-            'description': querystring.__doc__
+            'description': querystring.__doc__,
         })
         if issubclass(querystring.type, fields.Field):
             qs_dict['schema'] = {

--- a/pactum/exporters/openapi.py
+++ b/pactum/exporters/openapi.py
@@ -79,7 +79,7 @@ class OpenAPIV3Exporter(BaseVisitor):
 
         querystrings = action.parent.querystrings
         for qs in querystrings:
-            qs_dict = self._querystring_to_dict(action, qs)
+            qs_dict = self._querystring_to_dict(qs)
             result['parameters'].append(qs_dict)
 
     def _parameter_to_dict(self, action, parameter):
@@ -101,7 +101,7 @@ class OpenAPIV3Exporter(BaseVisitor):
 
         return param_dict
 
-    def _querystring_to_dict(self, action, querystring):
+    def _querystring_to_dict(self, querystring):
         qs_dict = ({
             'name': querystring.name,
             'in': 'query',

--- a/pactum/exporters/openapi.py
+++ b/pactum/exporters/openapi.py
@@ -55,6 +55,9 @@ class OpenAPIV3Exporter(BaseVisitor):
             # get, put, post, delete, options, head, patch and trace will be populated on children visits.
         }
 
+    def visit_querystring(self, querystring):
+        pass
+
     def visit_action(self, action):
         result = self.result['paths'][action.parent.path][action.request.verb.lower()] = {
             'description': action.__doc__,

--- a/pactum/fields.py
+++ b/pactum/fields.py
@@ -1,22 +1,7 @@
-from .base import Element
+from .base import KeyValueElement
 
 
-class Field(Element):
-    # noinspection PyShadowingBuiltins
-    def __init__(self, name=None, type=None, required=None, **kwargs):
-        super().__init__(**kwargs)
-        if required is None:
-            required = getattr(self, 'required', False)
-        self.required = required
-
-        if name is None:
-            name = getattr(self, 'name', '')
-        self.name = name
-
-        if type is None:
-            type = getattr(self, 'type', self.__class__)
-        self.type = type
-
+class Field(KeyValueElement):
     def accept(self, visitor):
         visitor.visit_field(self)
 

--- a/pactum/querystring.py
+++ b/pactum/querystring.py
@@ -1,0 +1,6 @@
+from .base import KeyValueElement
+
+
+class Querystring(KeyValueElement):
+    def accept(self, visitor):
+        visitor.visit_querystring(self)

--- a/pactum/route.py
+++ b/pactum/route.py
@@ -5,7 +5,7 @@ from .base import Element
 class Route(Element):
     _children_name = 'actions'
 
-    def __init__(self, path=None, actions=None, **kwargs):
+    def __init__(self, path=None, actions=None, querystrings=None, **kwargs):
         super().__init__(**kwargs)
         if path is None:
             try:
@@ -13,6 +13,14 @@ class Route(Element):
             except AttributeError:
                 raise TypeError("Missing path specification.")
         self.path = path
+
+        if querystrings is None:
+            querystrings = getattr(self, 'querystrings', [])
+        self.querystrings = querystrings
+
+        for querystring in self.querystrings:
+            querystring.parent = self
+
         self.parameters = self._get_parameters(path)
 
         self._initialize_children(locals())
@@ -25,3 +33,5 @@ class Route(Element):
         visitor.visit_route(self)
         for action in self.actions:
             action.accept(visitor)
+        for querystring in self.querystrings:
+            querystring.accept(visitor)

--- a/pactum/visitor.py
+++ b/pactum/visitor.py
@@ -11,6 +11,9 @@ class BaseVisitor:
     def visit_action(self, action):
         raise NotImplementedError('visit_action is not implemented')
 
+    def visit_querystring(self, action):
+        raise NotImplementedError('visit_querystring is not implemented')
+
     def visit_request(self, request):
         raise NotImplementedError('visit_request is not implemented')
 

--- a/samples/orders_api.py
+++ b/samples/orders_api.py
@@ -56,6 +56,11 @@ class OrderListRoute(pactum.Route):
             description='List Orders'
         )
     ]
+    querystrings = [
+        pactum.Querystring(
+            name='limit', type=fields.IntegerField,
+            description='Limits the number of order in the response')
+    ]
 
 
 class OrderDetailRoute(pactum.Route):

--- a/samples/orders_api.py
+++ b/samples/orders_api.py
@@ -59,7 +59,8 @@ class OrderListRoute(pactum.Route):
     querystrings = [
         pactum.Querystring(
             name='limit', type=fields.IntegerField,
-            description='Limits the number of order in the response')
+            description='Limits the number of order in the response'
+        ),
     ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import pytest
 from pactum import verbs
 from pactum.action import Action
 from pactum.api import API
+from pactum.querystring import Querystring
 from pactum.resources import Resource
 from pactum.request import Request
 from pactum.response import Response
@@ -52,3 +53,8 @@ def response():
 @pytest.fixture
 def action(request, response):
     return Action(request=request, responses=[response])
+
+
+@pytest.fixture
+def querystring():
+    return Querystring(name='test_querystring')

--- a/tests/test_exporters/test_openapi.py
+++ b/tests/test_exporters/test_openapi.py
@@ -140,7 +140,7 @@ def test_visit_action_populates_queries_with_route_qs():
         'in': 'query',
         'required': False,
         'schema': {'type': 'integer'},
-        'description': ''
+        'description': '',
     }
 
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -134,3 +134,10 @@ def test_basic_decimal_field_class_definition():
 def test_fail_basic_decimal_field_no_precision():
     with pytest.raises(TypeError):
         DecimalField(name='dec_field')
+
+
+def test_initialization_with_parameters_none():
+    field = Field(name=None, type=None, description=None)
+    assert field.type is Field
+    assert field.name == ''
+    assert field.__doc__ == ''

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -6,47 +6,47 @@ from pactum.resources import Resource
 
 def test_basic_field():
     field = Field(
-        name="TestField",
-        type="type",
+        name='TestField',
+        type='type',
     )
 
-    assert field.name == "TestField"
-    assert field.type == "type"
+    assert field.name == 'TestField'
+    assert field.type == 'type'
 
 
 def test_basic_field_class_definition():
     class TestField(Field):
-        name = "TestField"
-        type = "type"
+        name = 'TestField'
+        type = 'type'
 
     field = TestField()
-    assert field.name == "TestField"
-    assert field.type == "type"
+    assert field.name == 'TestField'
+    assert field.type == 'type'
 
 
 def test_basic_field_class_definition_with_class_name():
     class MyField(Field):
-        name = "name"
+        name = 'name'
 
     field = MyField()
-    assert field.name == "name"
+    assert field.name == 'name'
     assert field.type is MyField
 
 
 def test_field_type_can_be_class_name():
     field = Field(
-        name="TestField",
+        name='TestField',
     )
 
-    assert field.name == "TestField"
+    assert field.name == 'TestField'
     assert field.type == Field
 
 
 def test_integer_field():
-    int_field = IntegerField(name="my_name")
+    int_field = IntegerField(name='my_name')
 
     assert int_field.type == IntegerField
-    assert int_field.name == "my_name"
+    assert int_field.name == 'my_name'
     assert int_field.min_value is None
     assert int_field.max_value is None
 
@@ -62,7 +62,7 @@ def test_integer_field_class_field():
 
 
 def test_integer_field_min_max_values():
-    int_field = IntegerField(name="my_name", min_value=-5, max_value=5)
+    int_field = IntegerField(name='my_name', min_value=-5, max_value=5)
 
     assert int_field.type == IntegerField
     assert int_field.min_value == -5
@@ -70,67 +70,67 @@ def test_integer_field_min_max_values():
 
 
 def test_positive_integer_field():
-    int_field = PositiveIntegerField(name="my_name")
+    int_field = PositiveIntegerField(name='my_name')
 
     assert int_field.type == PositiveIntegerField
     assert int_field.min_value == 0
 
 
 def test_string_field():
-    str_field = StringField(name="my_name")
+    str_field = StringField(name='my_name')
 
     assert str_field.type == StringField
-    assert str_field.name == "my_name"
+    assert str_field.name == 'my_name'
 
 
 def test_resource_field(resource):
-    resource_field = ResourceField(name="my_field", resource=resource)
+    resource_field = ResourceField(name='my_field', resource=resource)
 
     assert resource_field.type == ResourceField
-    assert resource_field.name == "my_field"
+    assert resource_field.name == 'my_field'
     assert resource_field.resource == resource
 
 
 def test_resource_field_class_def(resource):
     class TestResourceField(ResourceField):
-        name = "my_field"
+        name = 'my_field'
         resource = Resource()
 
     resource_field = TestResourceField()
 
     assert resource_field.type == TestResourceField
-    assert resource_field.name == "my_field"
+    assert resource_field.name == 'my_field'
     assert isinstance(resource_field.resource, Resource)
 
 
 def test_fails__forresource_field_missing_ressource(resource):
     class TestResourceField(ResourceField):
-        name = "my_field"
+        name = 'my_field'
 
     with pytest.raises(TypeError):
         TestResourceField()
 
 
 def test_basic_decimal_field():
-    dec_field = DecimalField(name="dec_field", precision=2)
+    dec_field = DecimalField(name='dec_field', precision=2)
 
     assert dec_field.type == DecimalField
-    assert dec_field.name == "dec_field"
+    assert dec_field.name == 'dec_field'
     assert dec_field.precision == 2
 
 
 def test_basic_decimal_field_class_definition():
     class MyDecimalField(DecimalField):
-        name = "dec_field"
+        name = 'dec_field'
         precision = 2
 
     dec_field = MyDecimalField()
 
     assert dec_field.type == MyDecimalField
-    assert dec_field.name == "dec_field"
+    assert dec_field.name == 'dec_field'
     assert dec_field.precision == 2
 
 
 def test_fail_basic_decimal_field_no_precision():
     with pytest.raises(TypeError):
-        DecimalField(name="dec_field")
+        DecimalField(name='dec_field')

--- a/tests/test_querystring.py
+++ b/tests/test_querystring.py
@@ -3,37 +3,38 @@ from pactum.querystring import Querystring
 
 def test_basic_field():
     qs = Querystring(
-        name="TestField",
-        type="type",
+        name='TestField',
+        type='type',
     )
 
-    assert qs.name == "TestField"
-    assert qs.type == "type"
+    assert qs.name == 'TestField'
+    assert qs.type == 'type'
 
 
 def test_basic_field_class_definition():
     class TestQuerystring(Querystring):
-        name = "TestQuerystring"
-        type = "type"
+        name = 'TestQuerystring'
+        type = 'type'
 
     qs = TestQuerystring()
-    assert qs.name == "TestQuerystring"
-    assert qs.type == "type"
+    assert qs.name == 'TestQuerystring'
+    assert qs.type == 'type'
 
 
 def test_basic_field_class_definition_with_class_name():
     class MyQuerystring(Querystring):
-        name = "name"
+        name = 'name'
 
     qs = MyQuerystring()
-    assert qs.name == "name"
+    assert qs.name == 'name'
     assert qs.type is MyQuerystring
 
 
 def test_field_type_can_be_class_name():
     qs = Querystring(
-        name="TestField",
+        name='TestField',
     )
 
-    assert qs.name == "TestField"
+    assert qs.name == 'TestField'
+    assert qs.type == Querystring
     assert qs.type == Querystring

--- a/tests/test_querystring.py
+++ b/tests/test_querystring.py
@@ -1,0 +1,39 @@
+from pactum.querystring import Querystring
+
+
+def test_basic_field():
+    qs = Querystring(
+        name="TestField",
+        type="type",
+    )
+
+    assert qs.name == "TestField"
+    assert qs.type == "type"
+
+
+def test_basic_field_class_definition():
+    class TestQuerystring(Querystring):
+        name = "TestQuerystring"
+        type = "type"
+
+    qs = TestQuerystring()
+    assert qs.name == "TestQuerystring"
+    assert qs.type == "type"
+
+
+def test_basic_field_class_definition_with_class_name():
+    class MyQuerystring(Querystring):
+        name = "name"
+
+    qs = MyQuerystring()
+    assert qs.name == "name"
+    assert qs.type is MyQuerystring
+
+
+def test_field_type_can_be_class_name():
+    qs = Querystring(
+        name="TestField",
+    )
+
+    assert qs.name == "TestField"
+    assert qs.type == Querystring

--- a/tests/test_querystring.py
+++ b/tests/test_querystring.py
@@ -37,4 +37,10 @@ def test_field_type_can_be_class_name():
 
     assert qs.name == 'TestField'
     assert qs.type == Querystring
+
+
+def test_initialization_with_parameters_none():
+    qs = Querystring(name=None, type=None, description=None)
+    assert qs.name == ''
     assert qs.type == Querystring
+    assert qs.__doc__ == ''

--- a/tests/test_route.py
+++ b/tests/test_route.py
@@ -55,3 +55,19 @@ def test_route_with_multiple_parameters():
 
     assert route.path == '/test/{test_id}/{test.slug}/{test-uuid}'
     assert route.parameters == ['test_id', 'test.slug', 'test-uuid']
+
+
+def test_route_with_querystrings(querystring):
+    route = Route('/test/', querystrings=[querystring])
+    assert route.path == '/test/'
+    assert len(route.querystrings) == 1
+
+
+def test_class_defined_route_with_querystrings(querystring):
+    class TestRoute(Route):
+        path = '/test/'
+        querystrings = [querystring]
+
+    route = TestRoute()
+    assert route.path == '/test/'
+    assert len(route.querystrings) == 1


### PR DESCRIPTION
**What**
This PR adds the ability of adding querystrings to `Route` objects using a new element called `Querystring` that looks like `Field`.

**Why**
To be able to define routes with querystrings.

Story: https://jira-olist.atlassian.net/browse/OOCS-2
Task: https://jira-olist.atlassian.net/browse/OOCS-33