### PR TITLE
Add tests for accept methods.

### DIFF
--- a/pactum/action.py
+++ b/pactum/action.py
@@ -24,6 +24,7 @@ class Action(Element):
 
     def accept(self, visitor):
         visitor.visit_action(self)
-        self.request.accept(visitor)
+        if self.request:
+            self.request.accept(visitor)
         for response in self.responses:
             response.accept(visitor)

--- a/pactum/visitor.py
+++ b/pactum/visitor.py
@@ -11,7 +11,7 @@ class BaseVisitor:
     def visit_action(self, action):
         raise NotImplementedError('visit_action is not implemented')
 
-    def visit_querystring(self, action):
+    def visit_querystring(self, querystring):
         raise NotImplementedError('visit_querystring is not implemented')
 
     def visit_request(self, request):

--- a/tests/test_visitor.py
+++ b/tests/test_visitor.py
@@ -1,7 +1,11 @@
+import pytest
+
+from pactum import fields, verbs
+from pactum import API, Version, Route, Action, Request, Response, Querystring, Resource, ListResource
 from pactum.visitor import BaseVisitor
 
 
-class TestVisitor(BaseVisitor):
+class BlueprintVisitor(BaseVisitor):
     def __init__(self):
         self.blueprints = []
 
@@ -33,24 +37,118 @@ class TestVisitor(BaseVisitor):
         self.blueprints.append('field visited')
 
     def visit_list_resource(self, list_resource):
-        self.blueprints.append('list_resource visited')
+        self.blueprints.append('list resource visited')
 
 
-def test_visitor_call_order(api):
-    visitor = TestVisitor()
+@pytest.fixture
+def visitor():
+    return BlueprintVisitor()
+
+
+def test_visitor_api_call(visitor):
+    api = API(versions=[Version(name='v1', routes=[])])
     api.accept(visitor)
 
     assert visitor.blueprints == [
         'api visited',
         'version visited',
+    ]
+
+
+def test_visitor_version_call(visitor):
+    version = Version(name='v1', routes=[Route(path='/test')])
+    version.accept(visitor)
+
+    assert visitor.blueprints == [
+        'version visited',
+        'route visited',
+    ]
+
+
+def test_visitor_route_call(visitor):
+    route = Route(path='/test', actions=[Action(responses=[])])
+    route.accept(visitor)
+
+    assert visitor.blueprints == [
         'route visited',
         'action visited',
+    ]
+
+
+def test_visitor_route_call_with_querystring(visitor):
+    route = Route(
+        path='/test', actions=[Action(responses=[])], querystrings=[Querystring(name='test_qs')])
+    route.accept(visitor)
+
+    assert visitor.blueprints == [
+        'route visited',
+        'action visited',
+        'querystring visited',
+    ]
+
+
+def test_visitor_action_call(visitor):
+    action = Action(request=Request(verb=verbs.GET), responses=[Response(status=200)])
+    action.accept(visitor)
+
+    assert visitor.blueprints == [
+        'action visited',
+        'request visisted',
+        'response visited',
+    ]
+
+
+def test_visitor_request_call(visitor):
+    request = Request(verb=verbs.GET, payload=Resource())
+    request.accept(visitor)
+
+    assert visitor.blueprints == [
         'request visisted',
         'resource visited',
-        'field visited',
-        'response visited',
-        'list_resource visited',
-        'resource visited',
-        'field visited',
-        'querystring visited'
     ]
+
+
+def test_visitor_response_call(visitor):
+    response = Response(status=200, body=Resource())
+    response.accept(visitor)
+
+    assert visitor.blueprints == [
+        'response visited',
+        'resource visited',
+    ]
+
+
+def test_visitor_resource_call(visitor):
+    resource = Resource(fields=[fields.Field(name='test')])
+    resource.accept(visitor)
+
+    assert visitor.blueprints == [
+        'resource visited',
+        'field visited'
+    ]
+
+
+def test_visitor_list_resource_call(visitor):
+    list_resource = ListResource(resource=Resource())
+    list_resource.accept(visitor)
+
+    assert visitor.blueprints == [
+        'list resource visited',
+        'resource visited'
+    ]
+
+
+def test_visitor_field_call(visitor):
+    field = fields.Field(name='test')
+    field.accept(visitor)
+
+    assert visitor.blueprints == [
+        'field visited'
+    ]
+
+
+def test_visitor_querystring_call(visitor):
+    querystring = Querystring()
+    querystring.accept(visitor)
+
+    assert visitor.blueprints == ['querystring visited']

--- a/tests/test_visitor.py
+++ b/tests/test_visitor.py
@@ -77,7 +77,10 @@ def test_visitor_route_call(visitor):
 
 def test_visitor_route_call_with_querystring(visitor):
     route = Route(
-        path='/test', actions=[Action(responses=[])], querystrings=[Querystring(name='test_qs')])
+        path='/test',
+        actions=[Action(responses=[])],
+        querystrings=[Querystring(name='test_qs')]
+    )
     route.accept(visitor)
 
     assert visitor.blueprints == [
@@ -124,7 +127,7 @@ def test_visitor_resource_call(visitor):
 
     assert visitor.blueprints == [
         'resource visited',
-        'field visited'
+        'field visited',
     ]
 
 
@@ -134,7 +137,7 @@ def test_visitor_list_resource_call(visitor):
 
     assert visitor.blueprints == [
         'list resource visited',
-        'resource visited'
+        'resource visited',
     ]
 
 
@@ -143,7 +146,7 @@ def test_visitor_field_call(visitor):
     field.accept(visitor)
 
     assert visitor.blueprints == [
-        'field visited'
+        'field visited',
     ]
 
 
@@ -151,4 +154,6 @@ def test_visitor_querystring_call(visitor):
     querystring = Querystring()
     querystring.accept(visitor)
 
-    assert visitor.blueprints == ['querystring visited']
+    assert visitor.blueprints == [
+        'querystring visited',
+    ]

--- a/tests/test_visitor.py
+++ b/tests/test_visitor.py
@@ -1,0 +1,57 @@
+from pactum.visitor import BaseVisitor
+
+
+class TestVisitor(BaseVisitor):
+    def __init__(self):
+        self.blueprints = []
+
+    def visit_api(self, api):
+        self.blueprints.append('api visited')
+
+    def visit_version(self, version):
+        self.blueprints.append('version visited')
+
+    def visit_route(self, route):
+        self.blueprints.append('route visited')
+
+    def visit_action(self, action):
+        self.blueprints.append('action visited')
+
+    def visit_querystring(self, querystring):
+        self.blueprints.append('querystring visited')
+        return querystring
+
+    def visit_request(self, request):
+        self.blueprints.append('request visisted')
+
+    def visit_response(self, response):
+        self.blueprints.append('response visited')
+
+    def visit_resource(self, resource):
+        self.blueprints.append('resource visited')
+
+    def visit_field(self, field):
+        self.blueprints.append('field visited')
+
+    def visit_list_resource(self, list_resource):
+        self.blueprints.append('list_resource visited')
+
+
+def test_visitor_call_order(api):
+    visitor = TestVisitor()
+    api.accept(visitor)
+
+    assert visitor.blueprints == [
+        'api visited',
+        'version visited',
+        'route visited',
+        'action visited',
+        'request visisted',
+        'resource visited',
+        'field visited',
+        'response visited',
+        'list_resource visited',
+        'resource visited',
+        'field visited',
+        'querystring visited'
+    ]

--- a/tests/test_visitor.py
+++ b/tests/test_visitor.py
@@ -19,7 +19,6 @@ class TestVisitor(BaseVisitor):
 
     def visit_querystring(self, querystring):
         self.blueprints.append('querystring visited')
-        return querystring
 
     def visit_request(self, request):
         self.blueprints.append('request visisted')


### PR DESCRIPTION
**PLEASE READ THE DESCRIPTION**

What
Add tests for accept methods on pactum spec elements.

Why
Ensure call order of elements visit by visitor.

The accept methods were created to implement the visitor pattern for other visitor to create documentation, specifications in different formats or validators. The canonical visitor is the openapi exporter on https://github.com/olist/pactum/blob/master/pactum/exporters/openapi.py (tests here: https://github.com/olist/pactum/blob/master/tests/test_exporters/test_openapi.py).

There is a technical debt that the pattern implementation was not tested in the elements side. We just need to ensure that the visit will occur in a "parent -> child" order.

The accept methods for the pactum elements are at:
https://github.com/olist/pactum/blob/master/pactum/api.py#L16
https://github.com/olist/pactum/blob/master/pactum/version.py#L28
https://github.com/olist/pactum/blob/master/pactum/route.py#L32
https://github.com/olist/pactum/blob/master/pactum/action.py#L25
https://github.com/olist/pactum/blob/master/pactum/request.py#L18
https://github.com/olist/pactum/blob/master/pactum/response.py#L23
https://github.com/olist/pactum/blob/master/pactum/resources.py#L30
https://github.com/olist/pactum/blob/master/pactum/resources.py#L48
https://github.com/olist/pactum/blob/master/pactum/fields.py#L5
https://github.com/olist/pactum/blob/master/pactum/fields.py#L57

The code works and needs more robustness, but It wasn't tested. To add robustness we need these tests. 

References for visitor pattern:
https://en.wikipedia.org/wiki/Visitor_pattern
http://wiki.c2.com/?VisitorPattern
https://sourcemaking.com/design_patterns/visitor