### PR TITLE
Add support for fields specs using Fields inner class in Resources

### DIFF
--- a/pactum/resources.py
+++ b/pactum/resources.py
@@ -9,12 +9,16 @@ class BaseResource:
 
 
 class Resource(BaseResource):
-    def __init__(self, name=None, fields=None):
+    def __init__(self, name=None, fields=None, behaviors=None):
         super().__init__(name)
 
         self._mapfields = {}
         self.fields = []
         self._load_fields(fields)
+
+        if behaviors is None:
+            behaviors = getattr(self, "behavior", [])
+        self.behaviors = behaviors
 
     def _load_fields(self, fields):
         if fields is None:


### PR DESCRIPTION
# What

Add support for fields specification using an inner class `Fields` in resources.

# Why

Based on previous experience of @lamenezes on https://github.com/lamenezes/simple-model development we decided to allow developers to specify fields in resources using some kind of field definition like in Django Models.