### PR TITLE
[X9 Fix] Rename request fixture to request_.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ def resource():
 
 
 @pytest.fixture
-def request():
+def request_(): # `request` is a pytest reserved fixture.
     return Request(verb=verbs.GET)
 
 
@@ -51,8 +51,8 @@ def response():
 
 
 @pytest.fixture
-def action(request, response):
-    return Action(request=request, responses=[response])
+def action(request_, response):
+    return Action(request=request_, responses=[response])
 
 
 @pytest.fixture

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -3,10 +3,10 @@ import pytest
 from pactum.action import Action
 
 
-def test_basic_action(request, response):
-    test_action = Action(request=request, responses=[response], description="Test action")
+def test_basic_action(request_, response):
+    test_action = Action(request=request_, responses=[response], description="Test action")
 
-    assert test_action.request == request
+    assert test_action.request == request_
     assert test_action.responses == [response]
     assert test_action.responses[0].parent == test_action
     assert test_action.request.parent == test_action


### PR DESCRIPTION
Request is now a pytest reserved fixture.

### Why
Make project compliant with pytest contraints and make XP as a service warning stop.


### Additional info:
Pytest changelog from August 15th https://docs.pytest.org/en/latest/changelog.html#pytest-5-1-0-2019-08-15